### PR TITLE
Removes prod  target

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ npm run dev
 # build for production with minification
 npm run build
 
-# run server (after build)
-npm run prod
-
 # run unit tests
 npm run unit
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "scripts": {
     "dev": "node build/dev-server.js",
-    "prod": "node build/prod-server.js",
     "build": "node build/build.js",
     "unit": "karma start test/unit/karma.conf.js --single-run",
     "e2e": "node test/e2e/runner.js",


### PR DESCRIPTION
remove prod target because e3ce1fb removed build/prod-server.js so it `npm run prod` does not work anymore.