### PR TITLE
Fixed link to repo in Repos.vue

### DIFF
--- a/src/components/views/Repos.vue
+++ b/src/components/views/Repos.vue
@@ -27,9 +27,9 @@
                   </div>
                   <div class="col-sm-4 border-right">
                     <div class="description-block">
-                      <button type="button" class="btn btn-block btn-default btn-lg">
-                        <a v-bind:href="repo.owner.html_url" target="_blank">Visit</a>
-                      </button>
+                      <a v-bind:href="repo.owner.html_url" target="_blank">
+                        <button type="button" class="btn btn-block btn-default btn-lg">Visit</button>
+                      </a>
                     </div>
                   </div>
                   <div class="col-sm-4">

--- a/src/components/views/Repos.vue
+++ b/src/components/views/Repos.vue
@@ -28,7 +28,7 @@
                   <div class="col-sm-4 border-right">
                     <div class="description-block">
                       <a v-bind:href="repo.owner.html_url" target="_blank">
-                        <button type="button" class="btn btn-block btn-default btn-lg">Visit</button>
+                        <button type="button" class="btn btn-default btn-lg">Visit</button>
                       </a>
                     </div>
                   </div>


### PR DESCRIPTION
Moved href tag around button tag; original sequence didn't work on
Firefox 52.0.2 (Windows)