### PR TITLE
Fix active sidebar link

### DIFF
--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -1,30 +1,32 @@
 <template>
   <ul class="sidebar-menu">
     <li class="header">TOOLS</li>
-    <li class="pageLink">
-      <router-link to="/"><i class="fa fa-desktop"></i>
+    <router-link tag="li" class="pageLink" to="/">
+      <a>
+        <i class="fa fa-desktop"></i>
         <span class="page">Dashboard</span>
-      </router-link>
-    </li>
-    <li class="pageLink">
-      <router-link to="/tables"><i class="fa fa-table"></i>
+      </a>
+    </router-link>
+    <router-link tag="li" class="pageLink" to="/tables">
+      <a>
+        <i class="fa fa-table"></i>
         <span class="page">Tables</span>
-      </router-link>
-    </li>
+      </a>
+    </router-link>
 
     <li class="header">ME</li>
-    <li class="pageLink">
-      <router-link to="/tasks">
+    <router-link tag="li" class="pageLink" to="/tasks">
+      <a>
         <i class="fa fa-tasks"></i>
         <span class="page">Tasks</span>
-      </router-link>
-    </li>
-    <li class="pageLink">
-      <router-link to="/setting">
+      </a>
+    </router-link>
+    <router-link tag="li" class="pageLink" to="/setting">
+      <a>
         <i class="fa fa-cog"></i>
         <span class="page">Settings</span>
-      </router-link>
-    </li>
+      </a>
+    </router-link>
     <li class="treeview">
       <a href="#">
         <i class="fa fa-folder-o"></i>
@@ -53,35 +55,39 @@
     </li>
 
     <li class="header">LOGS</li>
-    <li class="pageLink">
-      <router-link to="/access"><i class="fa fa-book"></i>
+    <router-link tag="li" class="pageLink" to="/access">
+      <a>
+        <i class="fa fa-book"></i>
         <span class="page">Access</span>
-      </router-link>
-    </li>
-    <li class="pageLink">
-      <router-link to="/server"><i class="fa fa-hdd-o"></i>
+      </a>
+    </router-link>
+    <router-link tag="li" class="pageLink" to="/server">
+      <a>
+        <i class="fa fa-hdd-o"></i>
         <span class="page">Server</span>
-      </router-link>
-    </li>
-    <li class="pageLink">
-      <router-link to="/repos"><i class="fa fa-heart"></i>
+      </a>
+    </router-link>
+    <router-link tag="li" class="pageLink" to="/repos">
+      <a>
+        <i class="fa fa-heart"></i>
         <span class="page">Repos</span>
         <small class="label pull-right bg-green">AJAX</small>
-      </router-link>
-    </li>
+      </a>
+    </router-link>
 
     <li class="header">PAGES</li>
-    <li class="pageLink">
-      <router-link to="/login">
+    <router-link tag="li" class="pageLink" to="/login">
+      <a>
         <i class="fa fa-circle-o text-yellow"></i>
         <span class="page"> Login</span>
-      </router-link>
-    </li>
-    <li class="pageLink">
-      <router-link to="/404"><i class="fa fa-circle-o text-red"></i>
+      </a>
+    </router-link>
+    <router-link tag="li" class="pageLink" to="/404">
+      <a>
+        <i class="fa fa-circle-o text-red"></i>
         <span class="page"> 404</span>
-      </router-link>
-    </li>
+      </a>
+    </router-link>
   </ul>
 </template>
 <script>

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -1,25 +1,25 @@
 <template>
   <ul class="sidebar-menu">
     <li class="header">TOOLS</li>
-    <li class="active pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/"><i class="fa fa-desktop"></i>
         <span class="page">Dashboard</span>
       </router-link>
     </li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/tables"><i class="fa fa-table"></i>
         <span class="page">Tables</span>
       </router-link>
     </li>
 
     <li class="header">ME</li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/tasks">
         <i class="fa fa-tasks"></i>
         <span class="page">Tasks</span>
       </router-link>
     </li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/setting">
         <i class="fa fa-cog"></i>
         <span class="page">Settings</span>
@@ -53,17 +53,17 @@
     </li>
 
     <li class="header">LOGS</li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/access"><i class="fa fa-book"></i>
         <span class="page">Access</span>
       </router-link>
     </li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/server"><i class="fa fa-hdd-o"></i>
         <span class="page">Server</span>
       </router-link>
     </li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/repos"><i class="fa fa-heart"></i>
         <span class="page">Repos</span>
         <small class="label pull-right bg-green">AJAX</small>
@@ -71,13 +71,13 @@
     </li>
 
     <li class="header">PAGES</li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/login">
         <i class="fa fa-circle-o text-yellow"></i>
         <span class="page"> Login</span>
       </router-link>
     </li>
-    <li class="pageLink" v-on:click="toggleMenu">
+    <li class="pageLink">
       <router-link to="/404"><i class="fa fa-circle-o text-red"></i>
         <span class="page"> 404</span>
       </router-link>
@@ -86,20 +86,7 @@
 </template>
 <script>
 export default {
-  name: 'SidebarName',
-  methods: {
-    toggleMenu (event) {
-      // remove active from li
-      var active = document.querySelector('li.pageLink.active')
-
-      if (active) {
-        active.classList.remove('active')
-      }
-      // window.$('li.pageLink.active').removeClass('active')
-      // Add it to the item that was clicked
-      event.toElement.parentElement.className = 'pageLink active'
-    }
-  }
+  name: 'SidebarName'
 }
 </script>
 <style>

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ Vue.use(VueRouter)
 var router = new VueRouter({
   routes: routes,
   mode: 'history',
+  linkExactActiveClass: 'active',
   scrollBehavior: function (to, from, savedPosition) {
     return savedPosition || { x: 0, y: 0 }
   }


### PR DESCRIPTION
Fixes the issue listed at the bottom of #33

> Click for example tables, then refresh the page. You will still see the tables view, but on the navbar the dashboard is selected.

Fixed using native vue-router to set the `active` class on the `li` tags

https://router.vuejs.org/en/api/router-link.html#applying-active-class-to-outer-element
https://router.vuejs.org/en/api/options.html#linkexactactiveclass


