### PR TITLE
Shows text of Treeview in collapsed sidebar

### DIFF
--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -30,7 +30,7 @@
     <li class="treeview">
       <a href="#">
         <i class="fa fa-folder-o"></i>
-        <span>Files</span>
+        <span class="treeview-title">Files</span>
         <span class="pull-right-container">
           <i class="fa fa-angle-left fa-fw pull-right"></i>
         </span>
@@ -105,6 +105,10 @@ export default {
     animation-name: rotate;
     animation-duration: .2s;
     animation-fill-mode: forwards;
+  }
+  
+  .treeview-title {
+    z-index: 1;
   }
 
   @keyframes rotate {


### PR DESCRIPTION
In the collapsible list of links on the sidebar (known as a Treeview), the Treeview header's text did not show in the popup that appears when the sidebar is collapsed and the Treeview's icon is hovered over. This happened because the Treeview's collapse button (`fa-angle-left`) somehow interfered with the text that was shown.

This error is fixed by setting the Treeview header's text to have a z-index, which places the header's text in front of the collapse button. 

It now looks like this:

<img width="286" alt="screen shot 2018-04-16 at 11 35 43 am" src="https://user-images.githubusercontent.com/33555592/38820065-009f275c-416b-11e8-9257-d796b6485b94.png">

This PR fixes #69.
